### PR TITLE
Fix failing theme tests

### DIFF
--- a/packages/SqueakMaps-Tests.package/SMAThemeTests.class/instance/setUp.st
+++ b/packages/SqueakMaps-Tests.package/SMAThemeTests.class/instance/setUp.st
@@ -1,4 +1,6 @@
 running
 setUp
 	super setUp.
-	self squeakMapsWindow: SMAWindow new 
+	self world: (PasteUpMorph newWorldForProject: nil).
+	self squeakMapsWindow: SMAWindow new.
+	self world addMorph: self squeakMapsWindow

--- a/packages/SqueakMaps-Tests.package/SMAThemeTests.class/instance/testAdaptationTo.For..st
+++ b/packages/SqueakMaps-Tests.package/SMAThemeTests.class/instance/testAdaptationTo.For..st
@@ -1,6 +1,10 @@
 theme testing
 testAdaptationTo: anUserInterfaceTheme For: anObject
-	| expectedColor |
+	| themeRequest expectedColor |
 	anUserInterfaceTheme applyTo: {anObject}.
-	expectedColor := anObject userInterfaceTheme color.
+	themeRequest := UserInterfaceThemeRequest new
+		target: anObject;
+		theme: anUserInterfaceTheme;
+		yourself.
+	expectedColor := themeRequest color.
 	self assert: expectedColor equals: anObject color

--- a/packages/SqueakMaps-Tests.package/SMAThemeTests.class/instance/testAdaptationToCommunityTheme.st
+++ b/packages/SqueakMaps-Tests.package/SMAThemeTests.class/instance/testAdaptationToCommunityTheme.st
@@ -1,3 +1,3 @@
 theme testing
 testAdaptationToCommunityTheme
-	self testAdaptationTo: (CommunityTheme new)
+	self testAdaptationTo: (UserInterfaceTheme named: 'Community (dark)')

--- a/packages/SqueakMaps-Tests.package/SMAThemeTests.class/instance/testAdaptationToMonokaiTheme.st
+++ b/packages/SqueakMaps-Tests.package/SMAThemeTests.class/instance/testAdaptationToMonokaiTheme.st
@@ -1,3 +1,3 @@
 theme testing
 testAdaptationToMonokaiTheme
-	self testAdaptationTo: (MonokaiTheme new)
+	self testAdaptationTo: (UserInterfaceTheme named: 'Monokai (dark)')

--- a/packages/SqueakMaps-Tests.package/SMAThemeTests.class/instance/testAdaptationToSolarizedTheme.st
+++ b/packages/SqueakMaps-Tests.package/SMAThemeTests.class/instance/testAdaptationToSolarizedTheme.st
@@ -1,3 +1,3 @@
 theme testing
 testAdaptationToSolarizedTheme
-	self testAdaptationTo: (SolarizedTheme new)
+	self testAdaptationTo: (UserInterfaceTheme named: 'Solarized (dark)')

--- a/packages/SqueakMaps-Tests.package/SMAThemeTests.class/instance/testAdaptationToSqueakTheme.st
+++ b/packages/SqueakMaps-Tests.package/SMAThemeTests.class/instance/testAdaptationToSqueakTheme.st
@@ -1,3 +1,3 @@
 theme testing
 testAdaptationToSqueakTheme
-	self testAdaptationTo: (SqueakTheme new)
+	self testAdaptationTo: (UserInterfaceTheme named: 'Squeak')

--- a/packages/SqueakMaps-Tests.package/SMAThemeTests.class/instance/testAdaptationToTrimTheme.st
+++ b/packages/SqueakMaps-Tests.package/SMAThemeTests.class/instance/testAdaptationToTrimTheme.st
@@ -1,3 +1,3 @@
 theme testing
 testAdaptationToTrimTheme
-	self testAdaptationTo: (TrimTheme new)
+	self testAdaptationTo: (UserInterfaceTheme named: 'Trim (dark)')

--- a/packages/SqueakMaps-Tests.package/SMAThemeTests.class/instance/world..st
+++ b/packages/SqueakMaps-Tests.package/SMAThemeTests.class/instance/world..st
@@ -1,0 +1,3 @@
+accessing
+world: anObject
+	world := anObject

--- a/packages/SqueakMaps-Tests.package/SMAThemeTests.class/instance/world.st
+++ b/packages/SqueakMaps-Tests.package/SMAThemeTests.class/instance/world.st
@@ -1,0 +1,3 @@
+accessing
+world
+	^ world

--- a/packages/SqueakMaps-Tests.package/SMAThemeTests.class/methodProperties.json
+++ b/packages/SqueakMaps-Tests.package/SMAThemeTests.class/methodProperties.json
@@ -3,13 +3,15 @@
 		 },
 	"instance" : {
 		"runCase" : "",
-		"setUp" : "",
+		"setUp" : "RK 5/17/2022 11:29",
 		"squeakMapsWindow" : "",
 		"squeakMapsWindow:" : "",
 		"testAdaptationTo:" : "",
-		"testAdaptationTo:For:" : "",
-		"testAdaptationToCommunityTheme" : "",
-		"testAdaptationToMonokaiTheme" : "",
-		"testAdaptationToSolarizedTheme" : "",
-		"testAdaptationToSqueakTheme" : "",
-		"testAdaptationToTrimTheme" : "" } }
+		"testAdaptationTo:For:" : "RK 5/17/2022 11:22",
+		"testAdaptationToCommunityTheme" : "RK 5/17/2022 11:26",
+		"testAdaptationToMonokaiTheme" : "RK 5/17/2022 11:32",
+		"testAdaptationToSolarizedTheme" : "RK 5/17/2022 11:32",
+		"testAdaptationToSqueakTheme" : "RK 5/17/2022 11:33",
+		"testAdaptationToTrimTheme" : "RK 5/17/2022 11:33",
+		"world" : "RK 5/17/2022 11:31",
+		"world:" : "RK 5/17/2022 11:31" } }

--- a/packages/SqueakMaps-Tests.package/SMAThemeTests.class/properties.json
+++ b/packages/SqueakMaps-Tests.package/SMAThemeTests.class/properties.json
@@ -6,7 +6,8 @@
 		 ],
 	"commentStamp" : "cs 8/6/2020 15:16",
 	"instvars" : [
-		"squeakMapsWindow" ],
+		"squeakMapsWindow",
+		"world" ],
 	"name" : "SMAThemeTests",
 	"pools" : [
 		 ],


### PR DESCRIPTION
Closes #28. 

Tom hat darauf hingewiesen, dass es evtl. nicht sinnig ist, so viele Themes einzeln zu testen. Man sollte davon ausgehen können, dass wenn ein Theme geht auch die anderen gehen. Ich hab die Tests aber jetzt trotzdem mal drin gelassen, da es aktuell mehr Aufwand wäre den Code zu simplifizieren als einfach so zu lassen.