### PR TITLE
Handle error when searching for the same location

### DIFF
--- a/packages/SqueakMaps-Core.package/SMAWindow.class/instance/searchDirections.st
+++ b/packages/SqueakMaps-Core.package/SMAWindow.class/instance/searchDirections.st
@@ -16,6 +16,11 @@ searchDirections
 		do: [:error | ^ self inform: 'No location with name "' , error requestedName , '" found.'].
 	
 	self mapConfigurator clear.
+	
+	(startLocation coordinates = destinationLocation coordinates) ifTrue: [
+		self mapConfigurator displayLocation: startLocation.
+		self mapConfigurator focusLocation: startLocation.
+		^ self inform: 'Start and Destination Location are the same.'].
 
 	[route := self searchManager getRouteFrom: startLocation To: destinationLocation By: transportMode.]
 		on: Error

--- a/packages/SqueakMaps-Core.package/SMAWindow.class/methodProperties.json
+++ b/packages/SqueakMaps-Core.package/SMAWindow.class/methodProperties.json
@@ -73,7 +73,7 @@
 		"route" : "TR 7/6/2022 13:43",
 		"route:" : "TR 7/8/2022 09:31",
 		"savePin" : "RK 6/20/2022 21:37",
-		"searchDirections" : "TR 7/19/2022 16:36",
+		"searchDirections" : "TR 7/21/2022 18:10",
 		"searchInput" : "TR 6/25/2022 14:15",
 		"searchInput:" : "RK 7/13/2022 16:21",
 		"searchLocation" : "RK 7/18/2022 15:22",

--- a/packages/SqueakMaps-Tests.package/SMATests.class/instance/testDirectionsSameLocationSearch.st
+++ b/packages/SqueakMaps-Tests.package/SMATests.class/instance/testDirectionsSameLocationSearch.st
@@ -1,0 +1,17 @@
+searching
+testDirectionsSameLocationSearch
+
+	| placeName1 placeName2 errorText tiledMapMorph |
+
+	placeName1 := 'Berlin'.
+	placeName2 := 'Berlin'.
+	errorText :=  'Start and Destination Location are the same.'.
+	
+	tiledMapMorph := self squeakMapsWindow tiledMapMorph.
+
+	self squeakMapsWindow startSearchInput: placeName1.
+	self squeakMapsWindow destinationSearchInput: placeName2.
+
+	[self squeakMapsWindow searchDirections] valueSupplyingAnswer: {errorText. #closeDialog}.
+	self assert: tiledMapMorph markers size = 1.
+	self assert: (tiledMapMorph markers anySatisfy: [:marker | marker label includesSubstring: 'Berlin']).

--- a/packages/SqueakMaps-Tests.package/SMATests.class/methodProperties.json
+++ b/packages/SqueakMaps-Tests.package/SMATests.class/methodProperties.json
@@ -13,6 +13,7 @@
 		"testDeleteRouteOnSearch" : "TR 7/21/2022 08:41",
 		"testDirectionsLocationsTooFarApart" : "TR 7/20/2022 11:46",
 		"testDirectionsNoRouteExists" : "TR 7/20/2022 11:50",
+		"testDirectionsSameLocationSearch" : "TR 7/21/2022 18:13",
 		"testDirectionsValidRoute" : "TR 7/20/2022 12:03",
 		"testInvalidLocation" : "TR 7/19/2022 16:36",
 		"testLocationSearchingBerghain" : "TR 7/19/2022 16:35",


### PR DESCRIPTION
closes #70 
Einfacher Bug Fix, wenn man die gleiche Location sucht. Es wird der Pin der Location angezeigt und darauf gezoomt. Einen Test hab ich auch erstellt.